### PR TITLE
Anpassungen für Contao Manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,6 @@
     "branch-alias": {
       "dev-develop": "4.2.x-dev"
     }
+    "contao-manager-plugin": "Craffft\\ContaoCalendarICalBundle\\ContaoManager\\Plugin"
   }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Craffft\ContaoCalendarICalBundle;
+
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+
+class ContaoManagerPlugin implements BundlePluginInterface
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getBundles(ParserInterface $parser)
+	{
+		return [
+			BundleConfig::create(CraffftContaoCalendarICalBundle::class)
+				->setLoadAfter([ContaoCoreBundle::class])
+				->setReplace(['contaocalendar-ical-bundle']),
+		];
+	}
+}


### PR DESCRIPTION
Ich habe mal mit der [Anleitung von Bugbuster](https://docs.contao.ninja/de/erweiterung-c3-c4.html) Anpassungen für den Contao Manager vogenommen. 

Mit `->setReplace(['contaocalendar-ical-bundle']),` in `ContaoManager/Plugin.php` bin ich mir noch nicht ganz so sicher, da müsstest du nochmal bitte nachschauen.

Hoffentlich funktioniert dann endlich mal die Aktivierung über den CM. ;-)

Danke!