### PR TITLE
Korrektur Manager Plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   "extra": {
     "branch-alias": {
       "dev-develop": "4.2.x-dev"
-    }
+    },
     "contao-manager-plugin": "Craffft\\ContaoCalendarICalBundle\\ContaoManager\\Plugin"
   }
 }


### PR DESCRIPTION
Da fehlte noch ein Komma, deshalb kann aktuell Packagist nicht das Packet synchronisieren.
Entschuldige! Hoffe, dass es nun funktioniert...