### PR TITLE
Erneut: Aktivierung über CM

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -16,7 +16,7 @@ class Plugin implements BundlePluginInterface
         return [
             BundleConfig::create('Craffft\ContaoCalendarICalBundle\CraffftContaoCalendarICalBundle')
                 ->setLoadAfter(['Contao\CoreBundle\ContaoCoreBundle'])
-                ->setReplace(['cto-calendar-ical-bundle']),
+                ->setReplace(['contao-calendar-ical-bundle']),
         ];
 	}
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Craffft\ContaoCalendarICalBundle;
+namespace Craffft\ContaoCalendarICalBundle\ContaoManager;
 
-use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
-use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 
 class Plugin implements BundlePluginInterface
 {
@@ -14,10 +13,10 @@ class Plugin implements BundlePluginInterface
 	 */
 	public function getBundles(ParserInterface $parser)
 	{
-		return [
-			BundleConfig::create(CraffftContaoCalendarICalBundle::class)
-				->setLoadAfter([ContaoCoreBundle::class])
-				->setReplace(['contaocalendar-ical-bundle']),
-		];
+        return [
+            BundleConfig::create('Craffft\ContaoCalendarICalBundle\CraffftContaoCalendarICalBundle')
+                ->setLoadAfter(['Contao\CoreBundle\ContaoCoreBundle'])
+                ->setReplace(['cto-calendar-ical-bundle']),
+        ];
 	}
 }


### PR DESCRIPTION
Ich habe nochmal ein wenig geschaut und eine andere Variante für die Klassen genommen.
In meinen Testumgebungen hatte ich diesmal bei der Installation über den Contao Manager Erfolg gehabt, ohne dass das gesamte CMS abstürzt.

Am besten erstmal über den dev-master über Packagist zur Verfügung stellen, dann teste ich nochmal.