### PR TITLE
Verweis auf CSS

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -16,7 +16,7 @@
 $GLOBALS['TL_CTE']['files']['ical'] = 'ContentICal';
 
 $GLOBALS['BE_MOD']['content']['calendar']['import'] = array('CalendarImport', 'importCalendar');
-$GLOBALS['BE_MOD']['content']['calendar']['stylesheet'] = 'bundles/craffftcalendarical/calendar-ical.css';
+$GLOBALS['BE_MOD']['content']['calendar']['stylesheet'] = 'bundles/craffftcontaocalendarical/calendar-ical.css';
 
 /**
  * Cron jobs


### PR DESCRIPTION
Ggf. hilft das, damit das CSS wieder korrekt geladen werden kann.
Aktuell wird die Erweiterung jedoch nicht vollständig installiert. Nur die Tabellen aus der `tl_content.php` werden geladen und lassen sich über das Installtool anlegen, die Backendmodule sind ebenfalls nicht vorhanden.