### PR TITLE
Load after CalendarBundle instead of CoreBundle

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -15,7 +15,7 @@ class Plugin implements BundlePluginInterface
 	{
         return [
             BundleConfig::create('Craffft\ContaoCalendarICalBundle\CraffftContaoCalendarICalBundle')
-                ->setLoadAfter(['Contao\CoreBundle\ContaoCoreBundle'])
+                ->setLoadAfter(['Contao\CalendarBundle\ContaoCalendarBundle'])
                 ->setReplace(['contao-calendar-ical-bundle']),
         ];
 	}


### PR DESCRIPTION
This extension extends the CalendarBundle functionality, so it has to be loaded after the CalendarBundle.
I've had a problem where the DCA changes hadn't any effect, because the DCA of the CalendarBundle wasn't loaded. (Contao 4.4.14)