### PR TITLE
Establish compatibility with iCalcreator >= 2.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": ">=5.6.0",
     "contao/core-bundle": ">=4.2,<5.0",
-    "kigkonsult/icalcreator": "^2.24"
+    "kigkonsult/icalcreator": "2.27.*"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.0"

--- a/src/Resources/contao/classes/CalendarExport.php
+++ b/src/Resources/contao/classes/CalendarExport.php
@@ -12,8 +12,8 @@
 
 namespace Contao;
 
-use kigkonsult\iCalcreator\vcalendar;
-use kigkonsult\iCalcreator\vevent;
+use Kigkonsult\Icalcreator\Vcalendar;
+use Kigkonsult\Icalcreator\Vevent;
 
 class CalendarExport extends \Backend
 {
@@ -133,8 +133,7 @@ class CalendarExport extends \Backend
             return array();
         }
 
-        $ical = new vcalendar();
-        $ical->setConfig('ical_' . $this->id, 'aurealis.de');
+        $ical = new Vcalendar();
         $ical->setProperty('method', 'PUBLISH');
         $ical->setProperty("x-wr-calname", $title);
         $ical->setProperty("X-WR-CALDESC", $description);
@@ -164,7 +163,7 @@ class CalendarExport extends \Backend
             }
 
             while ($objEvents->next()) {
-                $vevent = new vevent();
+                $vevent = new Vevent();
 
                 if ($objEvents->addTime) {
                     $vevent->setProperty('dtstart', array(

--- a/src/Resources/contao/classes/CalendarImport.php
+++ b/src/Resources/contao/classes/CalendarImport.php
@@ -12,7 +12,7 @@
 
 namespace Contao;
 
-use kigkonsult\iCalcreator\vcalendar;
+use Kigkonsult\Icalcreator\Vcalendar;
 
 class CalendarImport extends \Backend
 {
@@ -98,8 +98,7 @@ class CalendarImport extends \Backend
 
     public function importFromWebICS($pid, $url, $startDate, $endDate, $timezone, $proxy, $benutzerpw, $port)
     {
-        $this->cal = new vcalendar();
-        $this->cal->setConfig('ical_' . $this->id, 'aurealis.de');
+        $this->cal = new Vcalendar();
         $this->cal->setProperty('method', 'PUBLISH');
         $this->cal->setProperty("x-wr-calname", $this->strTitle);
         $this->cal->setProperty("X-WR-CALDESC", $this->strTitle);
@@ -126,7 +125,7 @@ class CalendarImport extends \Backend
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             	if (!empty($proxy)) {
-			
+
             curl_setopt($ch, CURLOPT_PROXY, "$proxy");
             if (!empty($benutzerpw)) {
 			curl_setopt($ch, CURLOPT_PROXYUSERPWD , "$benutzerpw");		}
@@ -627,8 +626,7 @@ class CalendarImport extends \Backend
         $timeshift = 0
     ) {
         $pid = $dc->id;
-        $this->cal = new vcalendar();
-        $this->cal->setConfig('ical_' . $this->id, 'aurealis.de');
+        $this->cal = new Vcalendar();
         $this->cal->setProperty('method', 'PUBLISH');
         $this->cal->setProperty("x-wr-calname", $this->strTitle);
         $this->cal->setProperty("X-WR-CALDESC", $this->strTitle);

--- a/src/Resources/contao/classes/ContentICal.php
+++ b/src/Resources/contao/classes/ContentICal.php
@@ -12,8 +12,8 @@
 
 namespace Contao;
 
-use kigkonsult\iCalcreator\vcalendar;
-use kigkonsult\iCalcreator\vevent;
+use Kigkonsult\Icalcreator\Vcalendar;
+use Kigkonsult\Icalcreator\Vevent;
 
 class ContentICal extends ContentElement
 {
@@ -108,8 +108,7 @@ class ContentICal extends ContentElement
             return array();
         }
 
-        $this->ical = new vcalendar();
-        $this->ical->setConfig('ical_' . $this->id, 'aurealis.de');
+        $this->ical = new Vcalendar();
         $this->ical->setProperty('method', 'PUBLISH');
         $this->ical->setProperty("x-wr-calname",
             (strlen(\Input::get('title'))) ? \Input::get('title') : $this->strTitle);
@@ -129,7 +128,7 @@ class ContentICal extends ContentElement
             }
 
             while ($objEvents->next()) {
-                $vevent = new vevent();
+                $vevent = new Vevent();
 
                 if ($objEvents->addTime) {
                     $vevent->setProperty('dtstart', array(


### PR DESCRIPTION
This PR fixes #10.

* It uses the new class names introduced in [iCalcreator](https://github.com/iCalcreator/iCalcreator) 2.26 and establishes compatibility with the latest iCalcreator release 2.27.
* All occurrences of `vcalendar::setConfig('ical_...', ...)` have been removed without replacement.

  Apparently those calls previously [didn't have any effect](https://github.com/iCalcreator/iCalcreator/blob/v2.24.2/src/iCalBase.php#L259-L260) anyway, but instead of being ignored, [an exception is thrown](https://github.com/iCalcreator/iCalcreator/blob/v2.27.17/src/IcalBase.php#L587-L588) since iCalcreator 2.27.
* Since for some reason the author of iCalcreator [does not adhere to semantic versioning](https://github.com/iCalcreator/iCalcreator/issues/70#issuecomment-477033441), the dependency on `kigkonsult/icalcreator` has been constrained to version `2.27.*`. Any minor version upgrades should be regarded as possibly breaking and therefore be tested manually.
