### PR TITLE
Fix PHP 8 error in config.php

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -26,7 +26,7 @@ $GLOBALS['TL_CRON']['daily'][] = array('CalendarExport', 'generateSubscriptions'
 /**
  * Add 'ical' to the URL keywords to prevent problems with URL manipulating modules like folderurl
  */
-$GLOBALS['TL_CONFIG']['urlKeywords'] .= (strlen(trim($GLOBALS['TL_CONFIG']['urlKeywords'])) ? ',' : '') . 'ical';
+$GLOBALS['TL_CONFIG']['urlKeywords'] = (($GLOBALS['TL_CONFIG']['urlKeywords'] ?? null) ? $GLOBALS['TL_CONFIG']['urlKeywords'] . ',' : '') . 'ical';
 
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('CalendarExport', 'removeOldSubscriptions');
 $GLOBALS['TL_HOOKS']['getAllEvents'][] = array('CalendarImport', 'getAllEvents');


### PR DESCRIPTION
Fixes the following error under PHP 8:

```
ErrorException:
Warning: Undefined array key "urlKeywords"

  at vendor/craffft/contao-calendar-ical-bundle/src/Resources/contao/config/config.php:29
```